### PR TITLE
Refactor search params handling in LearningHub components

### DIFF
--- a/src/components/LearningHub/components/LearningHubNavbar.tsx
+++ b/src/components/LearningHub/components/LearningHubNavbar.tsx
@@ -2,8 +2,8 @@
 
 import { Search } from 'lucide-react'
 import Link from 'next/link'
-import { useRouter, useSearchParams } from 'next/navigation'
-import { HTMLAttributes, useMemo, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useMemo, useRef, useState } from 'react'
 
 import LogoIcon from '@/assets/icons/logo-icon.svg'
 import HomeHeader from '@/common/HomeHeader'
@@ -11,10 +11,11 @@ import ThemeSwitcher from '@/common/ThemeSwitcher'
 import { QueryFilters } from '@/components/LearningHub/constants'
 import { cn } from '@/theme/utils'
 
-type Props = Omit<HTMLAttributes<HTMLDivElement>, 'children'>
-
-export default function LearningHubNavbar({ className, ...rest }: Props) {
-  const searchParams = useSearchParams()
+export default function LearningHubNavbar({
+  searchParams,
+}: {
+  searchParams?: { [key: string]: string | string[] | undefined }
+}) {
   const router = useRouter()
 
   const [searchQuery, setSearchQuery] = useState('')
@@ -22,19 +23,17 @@ export default function LearningHubNavbar({ className, ...rest }: Props) {
   const searchInputRef = useRef<HTMLInputElement>(null)
 
   const sanitizedSearchParams = useMemo(() => {
-    const params = new URLSearchParams(searchParams)
+    const params = new URLSearchParams(searchParams as Record<string, string>)
     params.set(QueryFilters.Search, searchQuery)
     return params
   }, [searchParams, searchQuery])
 
   return (
     <div
-      {...rest}
       className={cn(
         'mx-auto w-full max-w-[1136px]',
         'flex items-center',
         'sm:px-6 sm:pt-8 lg:px-0',
-        className,
       )}
     >
       <Link href={'/'} className={cn('hidden', 'sm:flex')}>

--- a/src/components/LearningHub/index.tsx
+++ b/src/components/LearningHub/index.tsx
@@ -1,5 +1,3 @@
-import { Suspense } from 'react'
-
 import LearningHubFooter from '@/components/LearningHub/components/LearningHubFooter'
 import { cn } from '@/theme/utils'
 import { UiHorizontalDivider } from '@/ui'
@@ -8,16 +6,16 @@ import HeroSection from './components/HeroSection'
 import LearningHubNavbar from './components/LearningHubNavbar'
 import LearningHubPosts from './components/LearningHubPosts'
 
-export default function LearningHub({
+export default async function LearningHub({
   searchParams,
 }: {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }) {
+  const awaitedSearchParams = await searchParams
+
   return (
     <div className={cn('flex flex-col overflow-hidden bg-backgroundPrimary')}>
-      <Suspense>
-        <LearningHubNavbar />
-      </Suspense>
+      <LearningHubNavbar searchParams={awaitedSearchParams} />
 
       <div
         className={cn(
@@ -30,9 +28,7 @@ export default function LearningHub({
           data-aos='fade-in'
         />
 
-        <Suspense>
-          <LearningHubPosts searchParams={searchParams} />
-        </Suspense>
+        <LearningHubPosts searchParams={searchParams} />
 
         <UiHorizontalDivider className='mb-12 mt-14' />
 


### PR DESCRIPTION
Refactored `LearningHubNavbar` and `LearningHub` to properly handle `searchParams` as props and removed unused components like `Suspense`. This improves clarity and aligns with better prop management practices.